### PR TITLE
bugfix: handle absolute and relative paths as expected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 # misc
 .DS_Store
 dist/
+.vscode


### PR DESCRIPTION
Previous behavior would take the absolute or relative path and expand the directory structure onto the receiver. This is not what one expects when for instance sending files using the absolute path
`portal send /home/zinokader/data/somefile.txt`, 
which previously would actually try to recreate the same directory structure `/home/zinokader...` on the receiver end.

Now, we handle absolute paths by sending the last directory or file (and its subfiles/subdirectories), this means `/home/zinokader/folder` will just send and expand `folder` and all of its contents on the receiving end.

fixes #30 