### PR TITLE
feat: handle absolute and relative paths as expected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 # misc
 .DS_Store
 dist/
+.vscode

--- a/internal/rendezvous/handlers.go
+++ b/internal/rendezvous/handlers.go
@@ -29,7 +29,7 @@ func (s *Server) handleEstablishSender() http.HandlerFunc {
 		}
 		rc := conn.Rendezvous{Conn: c}
 
-		// Bind an ID to this communication and send ot to the sender
+		// Bind an ID to this communication and send to to the sender
 		id := s.ids.Bind()
 		defer func() { s.ids.Delete(id) }()
 		err = rc.WriteMsg(rendezvous.Msg{
@@ -110,7 +110,7 @@ func (s *Server) handleEstablishSender() http.HandlerFunc {
 	}
 }
 
-// handleEstablishReceiver returns a websocket handler that that communicates with the sender.
+// handleEstablishReceiver returns a websocket handler that communicates with the sender.
 func (s *Server) handleEstablishReceiver() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger, err := logger.FromContext(r.Context())

--- a/internal/rendezvous/mailbox.go
+++ b/internal/rendezvous/mailbox.go
@@ -20,7 +20,7 @@ func (mailboxes *Mailboxes) StoreMailbox(p string, m *Mailbox) {
 	mailboxes.Store(p, m)
 }
 
-// GetMailbox returns the decired mailbox.
+// GetMailbox returns the desired mailbox.
 func (mailboxes *Mailboxes) GetMailbox(p string) (*Mailbox, error) {
 	mailbox, ok := mailboxes.Load(p)
 	if !ok {

--- a/internal/rendezvous/server.go
+++ b/internal/rendezvous/server.go
@@ -26,17 +26,20 @@ type Server struct {
 // NewServer constructs a new Server struct and setups the routes.
 func NewServer(port int) *Server {
 	router := &mux.Router{}
+	lgr := logger.New()
+	stdLoggerWrapper, _ := zap.NewStdLogAt(lgr, zap.ErrorLevel)
 	s := &Server{
 		httpServer: &http.Server{
 			Addr:         fmt.Sprintf(":%d", port),
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: 30 * time.Second,
 			Handler:      router,
+			ErrorLog:     stdLoggerWrapper,
 		},
 		router:    router,
 		mailboxes: &Mailboxes{&sync.Map{}},
 		ids:       &IDs{&sync.Map{}},
-		logger:    logger.New(),
+		logger:    lgr,
 	}
 	s.routes()
 	return s


### PR DESCRIPTION
* chore: ignore .vscode folder

* feat: handle absolute and relative paths as expected

Previous behavior would take the absolute or relative path and
expand the directory structure onto the receiver. This is not what
one expects when for instance sending files using the absolute path
"portal send /home/zinokader/data/somefile.txt", which previously would
actually try to recreate the same directory structure "/home/zinokader..."
on the receiver end.

Now, we handle absolute paths by sending the last directory or file
(and its subfiles/subdirectories), this means "/home/zinokader/folder"
will just send and expand "folder" and all of its contents on the receiving end.