### PR TITLE
feat: file summary table

### DIFF
--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -121,22 +121,18 @@ func DecompressAndUnarchiveBytes(reader io.Reader) ([]string, int64, error) {
 	return createdFiles, decompressedSize, nil
 }
 
-// Traverses files and directories (recursively) for total size in bytes
-func FilesTotalSize(files []*os.File) (int64, error) {
+// Traverses a file or directory recursively for total size in bytes.
+func FileSize(filePath string) (int64, error) {
 	var size int64
-	for _, file := range files {
-		err := filepath.Walk(file.Name(), func(_ string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			if !info.IsDir() {
-				size += info.Size()
-			}
-			return err
-		})
+	err := filepath.Walk(filePath, func(_ string, info os.FileInfo, err error) error {
 		if err != nil {
-			return 0, err
+			return err
 		}
+		size += info.Size()
+		return err
+	})
+	if err != nil {
+		return 0, err
 	}
 	return size, nil
 }

--- a/ui/constants.go
+++ b/ui/constants.go
@@ -15,8 +15,9 @@ const (
 	MAX_WIDTH                = 80
 	PRIMARY_COLOR            = "#B8BABA"
 	SECONDARY_COLOR          = "#626262"
+	DARK_COLOR               = "#232323"
 	ELEMENT_COLOR            = "#EE9F40"
-	SECONDARY_ELEMENT_COLOR  = "#EE9F70"
+	SECONDARY_ELEMENT_COLOR  = "#e87d3e"
 	ERROR_COLOR              = "#CC0000"
 	WARNING_COLOR            = "#EE9F5C"
 	CHECK_COLOR              = "#34B233"
@@ -65,10 +66,12 @@ var Keys = KeyMap{
 	FileListUp: key.NewBinding(
 		key.WithKeys("up", "k"),
 		key.WithHelp("(↑/k)", "file summary up"),
+		key.WithDisabled(),
 	),
 	FileListDown: key.NewBinding(
 		key.WithKeys("down", "j"),
 		key.WithHelp("(↓/j)", "file summary down"),
+		key.WithDisabled(),
 	),
 }
 

--- a/ui/constants.go
+++ b/ui/constants.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -11,7 +10,8 @@ import (
 )
 
 const (
-	PADDING                  = 2
+	MARGIN                   = 2
+	PADDING                  = 1
 	MAX_WIDTH                = 80
 	PRIMARY_COLOR            = "#B8BABA"
 	SECONDARY_COLOR          = "#626262"
@@ -27,19 +27,29 @@ const (
 type KeyMap struct {
 	Quit         key.Binding
 	CopyPassword key.Binding
+	FileListUp   key.Binding
+	FileListDown key.Binding
 }
 
 func (k KeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.Quit,
 		k.CopyPassword,
+		k.FileListUp,
+		k.FileListDown,
 	}
 }
 
 func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.Quit, k.CopyPassword},
+		{k.Quit, k.CopyPassword, k.FileListUp, k.FileListDown},
 	}
+}
+
+func NewProgressBar() progress.Model {
+	p := progress.New(progress.WithGradient(SECONDARY_ELEMENT_COLOR, ELEMENT_COLOR))
+	p.PercentFormat = "  %.2f%%"
+	return p
 }
 
 var Keys = KeyMap{
@@ -49,30 +59,29 @@ var Keys = KeyMap{
 	),
 	CopyPassword: key.NewBinding(
 		key.WithKeys("c"),
-		key.WithHelp("(c)", "copy password to clipboard"),
+		key.WithHelp("(c)", CopyKeyHelpText),
 		key.WithDisabled(),
+	),
+	FileListUp: key.NewBinding(
+		key.WithKeys("up", "k"),
+		key.WithHelp("(↑/k)", "file summary up"),
+	),
+	FileListDown: key.NewBinding(
+		key.WithKeys("down", "j"),
+		key.WithHelp("(↓/j)", "file summary down"),
 	),
 }
 
-var QuitKeys = []string{"ctrl+c", "q", "esc"}
-var PadText = strings.Repeat(" ", PADDING)
-var QuitCommandsHelpText = HelpStyle(fmt.Sprintf("(any of [%s] to abort)", strings.Join(QuitKeys, ", ")))
+var PadText = strings.Repeat(" ", MARGIN)
+var BaseStyle = lipgloss.NewStyle()
 
-func NewProgressBar() progress.Model {
-	p := progress.New(progress.WithGradient(SECONDARY_ELEMENT_COLOR, ELEMENT_COLOR))
-	p.PercentFormat = "  %.2f%%"
-	return p
-}
+var InfoStyle = BaseStyle.Copy().Foreground(lipgloss.Color(PRIMARY_COLOR)).Render
+var HelpStyle = BaseStyle.Copy().Foreground(lipgloss.Color(SECONDARY_COLOR)).Render
+var ItalicText = BaseStyle.Copy().Italic(true).Render
+var BoldText = BaseStyle.Copy().Bold(true).Render
+var ErrorText = BaseStyle.Copy().Foreground(lipgloss.Color(ERROR_COLOR)).Render
+var WarningText = BaseStyle.Copy().Foreground(lipgloss.Color(WARNING_COLOR)).Render
+var CheckText = BaseStyle.Copy().Foreground(lipgloss.Color(CHECK_COLOR)).Render
 
-var baseStyle = lipgloss.NewStyle()
-
-var InfoStyle = baseStyle.Copy().Foreground(lipgloss.Color(PRIMARY_COLOR)).Render
-var HelpStyle = baseStyle.Copy().Foreground(lipgloss.Color(SECONDARY_COLOR)).Render
-var ItalicText = baseStyle.Copy().Italic(true).Render
-var BoldText = baseStyle.Copy().Bold(true).Render
-var ErrorText = baseStyle.Copy().Foreground(lipgloss.Color(ERROR_COLOR)).Render
-var WarningText = baseStyle.Copy().Foreground(lipgloss.Color(WARNING_COLOR)).Render
-var CheckText = baseStyle.Copy().Foreground(lipgloss.Color(CHECK_COLOR)).Render
-
-var CopyKeyHelpText = baseStyle.Render("copy password to clipboard")
-var CopyKeyActiveHelpText = CheckText("✓") + HelpStyle(" copied password to clipboard")
+var CopyKeyHelpText = BaseStyle.Render("password → clipboard")
+var CopyKeyActiveHelpText = CheckText("✓") + HelpStyle(" password → clipboard")

--- a/ui/filetable/filetable.go
+++ b/ui/filetable/filetable.go
@@ -1,0 +1,137 @@
+package filetable
+
+import (
+	"math"
+
+	"github.com/SpatiumPortae/portal/internal/file"
+	"github.com/SpatiumPortae/portal/ui"
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
+)
+
+const (
+	maxTableHeight                = 4
+	nameColumnWidthFactor float64 = 0.8
+	sizeColumnWidthFactor float64 = 1 - nameColumnWidthFactor
+)
+
+var fileTableStyle = ui.BaseStyle.Copy().
+	BorderStyle(lipgloss.RoundedBorder()).
+	BorderForeground(lipgloss.Color(ui.SECONDARY_COLOR)).
+	MarginLeft(ui.MARGIN)
+
+type Option func(m *Model)
+
+type fileRow struct {
+	path          string
+	formattedSize string
+}
+
+type Model struct {
+	Width int
+	rows  []fileRow
+	table table.Model
+}
+
+func New(opts ...Option) Model {
+	m := Model{
+		table: table.New(
+			table.WithFocused(true),
+			table.WithHeight(maxTableHeight),
+		),
+	}
+
+	s := table.DefaultStyles()
+	s.Header = s.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		BorderBottom(true).
+		Bold(true)
+	s.Selected = s.Selected.
+		Foreground(lipgloss.Color("229")).
+		Background(lipgloss.Color("57")).
+		Bold(false)
+	m.table.SetStyles(s)
+
+	m.updateColumns()
+	for _, opt := range opts {
+		opt(&m)
+	}
+
+	return m
+}
+
+func WithFiles(filePaths []string) Option {
+	return func(m *Model) {
+		for _, filePath := range filePaths {
+			size, err := file.FileSize(filePath)
+			var formattedSize string
+			if err != nil {
+				formattedSize = "N/A"
+			} else {
+				formattedSize = ui.ByteCountSI(size)
+			}
+			m.rows = append(m.rows, fileRow{path: filePath, formattedSize: formattedSize})
+		}
+		m.table.SetHeight(int(math.Min(maxTableHeight, float64(len(filePaths)))))
+		m.updateColumns()
+		m.updateRows()
+	}
+}
+
+func (m *Model) getMaxWidth() int {
+	return int(math.Min(ui.MAX_WIDTH-2*ui.MARGIN, float64(m.Width)))
+}
+
+func (m *Model) updateColumns() {
+	w := m.getMaxWidth()
+	m.table.SetColumns([]table.Column{
+		{Title: "File", Width: int(float64(w) * nameColumnWidthFactor)},
+		{Title: "Size", Width: int(float64(w) * sizeColumnWidthFactor)},
+	})
+}
+
+func (m *Model) updateRows() {
+	var tableRows []table.Row
+	maxFilePathWidth := int(float64(m.getMaxWidth()) * nameColumnWidthFactor)
+	for _, row := range m.rows {
+		path := row.path
+		// truncate overflowing file paths from the left
+		if len(path) > maxFilePathWidth {
+			overflowingLength := len(path) - maxFilePathWidth
+			path = runewidth.TruncateLeft(path, overflowingLength+1, "…")
+		}
+		tableRows = append(tableRows, table.Row{path, row.formattedSize})
+	}
+	m.table.SetRows(tableRows)
+}
+
+func (Model) Init() tea.Cmd {
+	return nil
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+
+	case tea.WindowSizeMsg:
+		m.Width = msg.Width - 2*ui.MARGIN - 4
+		if m.Width > ui.MAX_WIDTH {
+			m.Width = ui.MAX_WIDTH
+		}
+		m.updateColumns()
+		m.updateRows()
+		return m, nil
+
+	}
+
+	m.table, cmd = m.table.Update(msg)
+	return m, cmd
+}
+
+func (m Model) View() string {
+	return fileTableStyle.Render(m.table.View()) + "\n\n"
+}

--- a/ui/filetable/filetable.go
+++ b/ui/filetable/filetable.go
@@ -67,27 +67,35 @@ func New(opts ...Option) Model {
 	return m
 }
 
+func (m *Model) SetFiles(filePaths []string) {
+	for _, filePath := range filePaths {
+		size, err := file.FileSize(filePath)
+		var formattedSize string
+		if err != nil {
+			formattedSize = "N/A"
+		} else {
+			formattedSize = ui.ByteCountSI(size)
+		}
+		m.rows = append(m.rows, fileRow{path: filePath, formattedSize: formattedSize})
+	}
+	m.table.SetHeight(int(math.Min(float64(m.MaxHeight), float64(len(filePaths)))))
+	m.updateColumns()
+	m.updateRows()
+}
+
 func WithFiles(filePaths []string) Option {
 	return func(m *Model) {
-		for _, filePath := range filePaths {
-			size, err := file.FileSize(filePath)
-			var formattedSize string
-			if err != nil {
-				formattedSize = "N/A"
-			} else {
-				formattedSize = ui.ByteCountSI(size)
-			}
-			m.rows = append(m.rows, fileRow{path: filePath, formattedSize: formattedSize})
-		}
-		m.table.SetHeight(int(math.Min(float64(m.MaxHeight), float64(len(filePaths)))))
-		m.updateColumns()
-		m.updateRows()
+		m.SetFiles(filePaths)
 	}
+}
+
+func (m *Model) SetMaxHeight(height int) {
+	m.MaxHeight = height
 }
 
 func WithMaxHeight(height int) Option {
 	return func(m *Model) {
-		m.MaxHeight = height
+		m.SetMaxHeight(height)
 		m.updateRows()
 	}
 }

--- a/ui/receiver/receiver.go
+++ b/ui/receiver/receiver.go
@@ -177,7 +177,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			ui.ByteCountSI(m.transferProgress.TransferSpeedEstimateBps),
 		)
 
-		filetable.WithMaxHeight(math.MaxInt)(&m.fileTable)
+		m.fileTable.SetMaxHeight(math.MaxInt)
 		m.fileTable = m.fileTable.Finalize().(filetable.Model)
 		return m, ui.TaskCmd(message, tea.Batch(m.spinner.Tick, decompressCmd(msg.temp)))
 
@@ -186,7 +186,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.receivedFiles = msg.filenames
 		m.decompressedPayloadSize = msg.decompressedPayloadSize
 
-		filetable.WithFiles(m.receivedFiles)(&m.fileTable)
+		m.fileTable.SetFiles(m.receivedFiles)
 		return m, ui.QuitCmd()
 
 	case ui.ErrorMsg:

--- a/ui/receiver/receiver.go
+++ b/ui/receiver/receiver.go
@@ -240,7 +240,7 @@ func (m model) View() string {
 			ui.PadText + m.help.View(m.keys) + "\n\n"
 
 	case showFinished:
-		indentedWrappedFiles := indent.String(fmt.Sprintf("Received: %s", wordwrap.String(ui.ItalicText(ui.TopLevelFilesText(m.receivedFiles)), ui.MAX_WIDTH)), ui.PADDING)
+		indentedWrappedFiles := indent.String(fmt.Sprintf("Received: %s", wordwrap.String(ui.ItalicText(ui.TopLevelFilesText(m.receivedFiles)), ui.MAX_WIDTH)), ui.MARGIN)
 
 		var oneOrMoreFiles string
 		if len(m.receivedFiles) > 1 {
@@ -342,6 +342,6 @@ func (m *model) resetSpinner() {
 		m.spinner.Spinner = ui.CompressingSpinner
 	}
 	if m.state == showReceivingProgress {
-		m.spinner.Spinner = ui.TransferSpinner
+		m.spinner.Spinner = ui.ReceivingSpinner
 	}
 }

--- a/ui/transferprogress/transferprogress.go
+++ b/ui/transferprogress/transferprogress.go
@@ -59,7 +59,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 
 	case tea.WindowSizeMsg:
-		m.Width = msg.Width - 2*ui.PADDING - 4
+		m.Width = msg.Width - 2*ui.MARGIN - 4
 		if m.Width > ui.MAX_WIDTH {
 			m.Width = ui.MAX_WIDTH
 		}

--- a/ui/transferprogress/transferprogress.go
+++ b/ui/transferprogress/transferprogress.go
@@ -3,6 +3,7 @@ package transferprogress
 import (
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/SpatiumPortae/portal/ui"
@@ -46,12 +47,22 @@ func (Model) Init() tea.Cmd {
 }
 
 func (m Model) View() string {
-	bytesProgress := fmt.Sprintf("(%s/%s, %s/s)",
-		ui.ByteCountSI(m.bytesTransferred), ui.ByteCountSI(m.PayloadSize), ui.ByteCountSI(m.TransferSpeedEstimateBps))
-	eta := fmt.Sprintf("%v remaining", m.estimatedRemainingDuration.Round(time.Second).String())
+	bytesProgress := strings.Builder{}
+	bytesProgress.WriteRune('(')
+	bytesProgress.WriteString(fmt.Sprintf("%s/%s", ui.ByteCountSI(m.bytesTransferred), ui.ByteCountSI(m.PayloadSize)))
+	if m.TransferSpeedEstimateBps > 0 {
+		bytesProgress.WriteString(fmt.Sprintf(", %s/s", ui.ByteCountSI(m.TransferSpeedEstimateBps)))
+	}
+	bytesProgress.WriteRune(')')
+
+	secondsRemaining := m.estimatedRemainingDuration.Round(time.Second)
+	var eta string
+	if secondsRemaining > 0 {
+		eta = fmt.Sprintf("%v remaining", secondsRemaining.String())
+	}
 	progressBar := m.progressBar.ViewAs(m.progress)
 
-	return bytesProgress + "\t\t" + eta + "\n\n" +
+	return bytesProgress.String() + "\t\t" + eta + "\n\n" +
 		ui.PadText + progressBar
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -49,21 +49,21 @@ var CompressingSpinner = spinner.Spinner{
 }
 
 var TransferSpinner = spinner.Spinner{
-	Frames: []string{"»  ", "»» ", "»»»", "   "},
+	Frames: []string{"⇢┄┄", "┄⇢┄", "┄┄⇢", "┄┄┄"},
 	FPS:    time.Millisecond * 400,
 }
 
 var ReceivingSpinner = spinner.Spinner{
-	Frames: []string{"   ", "  «", " ««", "«««"},
+	Frames: []string{"┄┄┄", "┄┄⇠", "┄⇠┄", "⇠┄┄"},
 	FPS:    time.Second / 2,
 }
 
 // --------------------------------------------------- Shared Helpers --------------------------------------------------
 
 func LogSeparator(width int) string {
-	paddedWidth := math.Max(0, float64(width)-2*PADDING)
+	paddedWidth := math.Max(0, float64(width)-2*MARGIN)
 	return fmt.Sprintf("%s\n\n",
-		baseStyle.Copy().
+		BaseStyle.Copy().
 			Foreground(lipgloss.Color(SECONDARY_COLOR)).
 			Render(strings.Repeat("─", int(math.Min(MAX_WIDTH, paddedWidth)))))
 }


### PR DESCRIPTION
- a summary of sent/received files are shown during/after transfer

- for the sender, the summary shows up to 4 rows at a time and can be scrolled with `uparrow/k` and `downarrow/j`

- for the receiver, the summary can only be shown after transfer and is therefore expanded to show all rows (all received files) before exiting the program

- finished state for both sender and receiver removes cell selection styling and shows all sent/received files in uncolored plaintext