### PR TITLE
fix: get latest version from relay endpoint, cache version results

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,8 @@
+package cache
+
+import "time"
+
+type Storage interface {
+	Get(key string) []byte
+	Set(key string, content []byte, duration time.Duration)
+}

--- a/internal/cache/memory/cache.go
+++ b/internal/cache/memory/cache.go
@@ -1,0 +1,58 @@
+package memory
+
+import (
+	"sync"
+	"time"
+)
+
+// Item is a cached reference
+type Item struct {
+	Content    []byte
+	Expiration int64
+}
+
+// Expired returns true if the item has expired.
+func (item Item) Expired() bool {
+	if item.Expiration == 0 {
+		return false
+	}
+	return time.Now().UnixNano() > item.Expiration
+}
+
+// Storage mecanism for caching strings in memory
+type Storage struct {
+	items map[string]Item
+	mu    *sync.RWMutex
+}
+
+// NewStorage creates a new in memory storage
+func NewStorage() *Storage {
+	return &Storage{
+		items: make(map[string]Item),
+		mu:    &sync.RWMutex{},
+	}
+}
+
+// Get a cached content by key
+func (s Storage) Get(key string) []byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	item := s.items[key]
+	if item.Expired() {
+		delete(s.items, key)
+		return nil
+	}
+	return item.Content
+}
+
+// Set a cached content by key
+func (s Storage) Set(key string, content []byte, duration time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.items[key] = Item{
+		Content:    content,
+		Expiration: time.Now().Add(duration).UnixNano(),
+	}
+}

--- a/internal/cache/middleware.go
+++ b/internal/cache/middleware.go
@@ -1,0 +1,32 @@
+package cache
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+func Middleware(storage Storage, duration string, handler func(w http.ResponseWriter, r *http.Request)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		content := storage.Get(r.RequestURI)
+		if content != nil {
+			w.Write(content)
+		} else {
+			c := httptest.NewRecorder()
+			handler(c, r)
+
+			for k, v := range c.Result().Header {
+				w.Header()[k] = v
+			}
+
+			w.WriteHeader(c.Code)
+			content := c.Body.Bytes()
+
+			if d, err := time.ParseDuration(duration); err == nil {
+				storage.Set(r.RequestURI, content, d)
+			}
+
+			w.Write(content)
+		}
+	})
+}

--- a/internal/cache/middleware.go
+++ b/internal/cache/middleware.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+//nolint:errcheck
 func Middleware(storage Storage, duration string, handler func(w http.ResponseWriter, r *http.Request)) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		content := storage.Get(r.RequestURI)

--- a/internal/rendezvous/handlers.go
+++ b/internal/rendezvous/handlers.go
@@ -239,6 +239,25 @@ func (s *Server) ping() http.HandlerFunc {
 	}
 }
 
+func (s *Server) handleVersionCheck() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		logger, err := logger.FromContext(ctx)
+		if err != nil {
+			return
+		}
+
+		res, err := http.Get("https://api.github.com/repos/SpatiumPortae/portal/releases?per_page=1")
+		if err != nil {
+			logger.Error("fetching latest version tag from GitHub releases API", zap.Error(err))
+			return
+		}
+		defer res.Body.Close()
+
+		io.Copy(w, res.Body)
+	}
+}
+
 // ------------------------------------------------------ Helpers ------------------------------------------------------
 
 // forwarder reads from the connection and forwards the message to the provided channel.

--- a/internal/rendezvous/handlers.go
+++ b/internal/rendezvous/handlers.go
@@ -239,6 +239,7 @@ func (s *Server) ping() http.HandlerFunc {
 	}
 }
 
+//nolint:errcheck
 func (s *Server) handleVersionCheck() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()

--- a/internal/rendezvous/routes.go
+++ b/internal/rendezvous/routes.go
@@ -1,14 +1,19 @@
 package rendezvous
 
 import (
+	"github.com/SpatiumPortae/portal/internal/cache"
 	"github.com/SpatiumPortae/portal/internal/conn"
 	"github.com/SpatiumPortae/portal/internal/logger"
 )
 
 func (s *Server) routes() {
 	s.router.HandleFunc("/ping", s.ping())
+
 	portal := s.router.PathPrefix("").Subrouter()
-	portal.Use(logger.Middleware(s.logger), conn.Middleware())
-	portal.HandleFunc("/establish-sender", s.handleEstablishSender())
-	portal.HandleFunc("/establish-receiver", s.handleEstablishReceiver())
+	portal.Use(logger.Middleware(s.logger))
+
+	portal.Handle("/version", cache.Middleware(s.storage, "1h", s.handleVersionCheck()))
+
+	portal.Handle("/establish-sender", conn.Middleware()(s.handleEstablishSender()))
+	portal.Handle("/establish-receiver", conn.Middleware()(s.handleEstablishReceiver()))
 }

--- a/internal/rendezvous/server.go
+++ b/internal/rendezvous/server.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/SpatiumPortae/portal/internal/cache"
+	"github.com/SpatiumPortae/portal/internal/cache/memory"
 	"github.com/SpatiumPortae/portal/internal/logger"
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
@@ -20,6 +22,7 @@ type Server struct {
 	mailboxes  *Mailboxes
 	ids        *IDs
 	signal     chan os.Signal
+	storage    cache.Storage
 	logger     *zap.Logger
 }
 
@@ -39,6 +42,7 @@ func NewServer(port int) *Server {
 		router:    router,
 		mailboxes: &Mailboxes{&sync.Map{}},
 		ids:       &IDs{&sync.Map{}},
+		storage:   memory.NewStorage(),
 		logger:    lgr,
 	}
 	s.routes()

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -97,25 +97,27 @@ func (sv Version) Patch() int {
 }
 
 func GetPortalLatest() (Version, error) {
-	r, err := http.Get("https://api.github.com/repos/SpatiumPortae/portal/releases?per_page=1")
+	// TODO: refactor hardcoded IP once spatiumportae domain is setup.
+	// we do want this function to get the version from the DO relay, always, though.
+	r, err := http.Get(fmt.Sprintf("https://%s/version", "167.71.65.96"))
 	if err != nil {
-		return Version{}, fmt.Errorf("fetching the latest tag from github: %w", err)
+		return Version{}, fmt.Errorf("fetching the latest version: %w", err)
 	}
 	type tag struct {
 		Name string `json:"tag_name"`
 	}
 	var tags []tag
 	if err := json.NewDecoder(r.Body).Decode(&tags); err != nil {
-		return Version{}, fmt.Errorf("decoding response from github: %w", err)
+		return Version{}, fmt.Errorf("decoding version check response: %w", err)
 	}
 	if len(tags) < 1 {
-		return Version{}, fmt.Errorf("no tags returned from github: %w", err)
+		return Version{}, fmt.Errorf("no version tags returned from version check: %w", err)
 	}
 	vers := make([]Version, len(tags))
 	for i := range tags {
 		v, err := Parse(tags[i].Name)
 		if err != nil {
-			return Version{}, fmt.Errorf("unable to parse tag to semver: %w", err)
+			return Version{}, fmt.Errorf("unable to parse version tag to semver: %w", err)
 		}
 		vers[i] = v
 	}


### PR DESCRIPTION
Sending multiple files in (not particularly) quick succession would trigger the rate limits for the GitHub releases API. That could be fixed by making the version check optional and actually let the client hit the rate limit, although for a more consistent experience this PR makes it so that version checks are made against the DigitalOcean relay server which in turn proxies and caches requests to the GitHub API for 1h.