### PR TITLE
feat: Add support for ignoring files using gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@
 *.wasm
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
 
 # misc
 .DS_Store

--- a/cmd/portal/commands/send.go
+++ b/cmd/portal/commands/send.go
@@ -30,6 +30,9 @@ func Send(version string) *cobra.Command {
 			if err := viper.BindPFlag("tui_style", cmd.Flags().Lookup("tui-style")); err != nil {
 				return fmt.Errorf("binding tui-style flag: %w", err)
 			}
+			if err := viper.BindPFlag("gitignore", cmd.Flags().Lookup("gitignore")); err != nil {
+				return fmt.Errorf("binding gitignore flag: %w", err)
+			}
 			return nil
 
 		},
@@ -58,6 +61,7 @@ func Send(version string) *cobra.Command {
 	}
 	sendCmd.Flags().StringP("relay", "r", "", relayFlagDesc)
 	sendCmd.Flags().StringP("tui-style", "s", "", tuiStyleFlagDesc)
+	sendCmd.Flags().BoolP("gitignore", "i", false, "Use .gitignore files to ignore files in git repositories")
 	return sendCmd
 }
 
@@ -103,7 +107,7 @@ func handleSendCommandRaw(version string, filenames []string) error {
 		defer f.Close()
 		files = append(files, f)
 	}
-	payload, size, err := file.PackFiles(files)
+	payload, size, err := file.PackFiles(files, viper.GetBool("gitignore"))
 	if err != nil {
 		return fmt.Errorf("error packing files: %w", err)
 	}

--- a/cmd/portal/commands/send.go
+++ b/cmd/portal/commands/send.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/SpatiumPortae/portal/cmd/portal/config"
 	sender_ui "github.com/SpatiumPortae/portal/cmd/portal/tui/sender"
@@ -44,6 +45,12 @@ func Send(version string) *cobra.Command {
 				return err
 			}
 			defer logFile.Close()
+			if viper.GetBool("gitignore") {
+				_, err := exec.LookPath("git")
+				if err != nil {
+					return fmt.Errorf("checking if git is installed: %w", err)
+				}
+			}
 			switch viper.GetString("tui_style") {
 			case config.StyleRich:
 				if err := handleSendCommand(version, args); err != nil {

--- a/cmd/portal/config/config.go
+++ b/cmd/portal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	PromptOverwriteFiles bool   `mapstructure:"prompt_overwrite_files"`
 	RelayServePort       int    `mapstructure:"relay_serve_port"`
 	TuiStyle             string `mapstructure:"tui_style"`
+	Gitignore            bool   `mapstructure:"gitignore"`
 }
 
 func GetDefault() Config {
@@ -36,6 +37,7 @@ func GetDefault() Config {
 		PromptOverwriteFiles: true,
 		RelayServePort:       8080,
 		TuiStyle:             StyleRich,
+		Gitignore:            false,
 	}
 }
 

--- a/cmd/portal/tui/sender/sender.go
+++ b/cmd/portal/tui/sender/sender.go
@@ -410,7 +410,7 @@ func compressFilesCmd(files []*os.File) tea.Cmd {
 				f.Close()
 			}
 		}()
-		tar, size, err := file.PackFiles(files)
+		tar, size, err := file.PackFiles(files, viper.GetBool("gitignore"))
 		if err != nil {
 			return tui.ErrorMsg(err)
 		}

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -396,17 +396,3 @@ func isGitRoot(path string) (bool, error) {
 	root := strings.ReplaceAll(stdout.String(), "\n", "")
 	return root == abs, nil
 }
-
-// glob returns a glob of file paths (mimicking the behavior of "*/**" in linux) called from the
-// provided root. Files in the .git folder will be ignored.
-func glob(root string) []string {
-	var result []string
-	filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if d.IsDir() && d.Name() == ".git" {
-			return filepath.SkipDir
-		}
-		result = append(result, strings.TrimPrefix(path, fmt.Sprintf("%s%c", root, os.PathSeparator)))
-		return nil
-	})
-	return result
-}

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"


### PR DESCRIPTION
If the `--gitignore` flag is supplied the behavior is:
- If a root git repository is supplied to `portal send` files in the repository will be ignored according to gitignore file
- All other cases (including folders in a git repository) will be sent regularly.
- .git folders are always sent

Example:
```
.
├── dir
│   └── file.txt
└── gitrepository
    ├── .gitignore
    ├── .git
    │   ├── HEAD
    │   ├── config
    │   ├── description
    │   ├── hooks
    │   ├── info
    │   ├── objects
    │   └── refs
    ├── main.go
    └── somedir
        └── file.go

# .gitignore
somedir/
```
- `portal send gitrepository dir --gitignore` would send
  - `dir/file.txt`
  - `gitrepository/.gitignore`
  - `gitrepository/.git/`
  - `gitrepository/main.go`

- `portal send gitrepository/somedir --gitignire` would send
  - `gitrepository/somedir/file.go`
  
The feature is implemented by issuing git shell commands, which reduces the complexity of writing a gitignore parser instead relying on the actual git ignore implementation. However, if we are to use this approach we would make sure to test it in other shells (other than bash and zsh) like (powershell and cmd etc).

solves #97 