### PR TITLE
fix: ARM64 architecture detection

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,9 +56,9 @@ function install {
 	*) fail "unknown os: $(uname -s)";;
 	esac
 	# find ARCH
-	if uname -m | grep 64 > /dev/null; then
+	if uname -m | grep amd64 > /dev/null; then
 		ARCH="amd64"
-	elif uname -m | grep arm > /dev/null; then
+	elif uname -m | grep 'arm\|aarch64' > /dev/null; then
 		ARCH="arm"
 	else
 		fail "unknown arch: $(uname -m)"


### PR DESCRIPTION
Currently running the install script on a ARM64 device such as a Raspberry Pi 5 yields a `uname -m` of `aarch64`, which is synonymous with ARM64. However before this change the script would download the x86 version.

Tested on `Ubuntu 24.04 Server` on a `Raspberry Pi 5`.